### PR TITLE
Ensure warning icon size is not overridden by site specific css

### DIFF
--- a/content.js
+++ b/content.js
@@ -35,7 +35,7 @@ new function() {
 			icon = document.createElement('img');
 			icon.src = chrome.extension.getURL('img/error_38.png');
 			icon.title = 'Some errors occurred on this page. Click to see details.';
-			icon.style.cssText = 'position: fixed !important; bottom: 10px !important; right: 10px !important; cursor: pointer !important; z-index: 2147483647 !important;';
+			icon.style.cssText = 'position: fixed !important; bottom: 10px !important; right: 10px !important; cursor: pointer !important; z-index: 2147483647 !important; width: 48px !important; height: auto !important;';
 			icon.onclick = function() {
 				if(!popup) {
 					showPopup(popupUrl);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name": "JavaScript Errors Notifier",
 	"short_name": "js_error",
 	"description": "Notifies JavaScript errors by icon in toolbar bar or notification popup",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"manifest_version": 2,
 	"background": {
 		"scripts": [


### PR DESCRIPTION
Hi,

First thing thanks for this great extension, it's extremely useful and it has been part of my toolkit for more than one year.

Recently I updated the extension and I browsed to the following site: [http://www.internazionale.it/](http://www.internazionale.it/) and they use the following css rule:

`img {
    width: 100%;
    border-width: 0;
    vertical-align: middle;
    -ms-interpolation-mode: bicubic;
}`

and unfortunately it leads to the following result:
![screen shot 2016-03-22 at 11 04 59](https://cloud.githubusercontent.com/assets/983189/13950392/9c606d3c-f022-11e5-9cbd-a8eec9e854a3.png)

I've tested this more than twice and it seems to address the issue.

Many thanks,

Riccardo