### PR TITLE
Support chrome.notifications

### DIFF
--- a/background.js
+++ b/background.js
@@ -213,6 +213,16 @@ function handleErrorsRequest(data, sender, sendResponse) {
 			}
 		}
 
+		popupErrors.forEach(function(err) {
+			chrome.notifications.create(undefined, {
+				type: "basic",
+				title: tabBaseUrl,
+				message: err.text,
+				contextMessage: err.subtext,
+				iconUrl: "img/error_38.png",
+			});
+		});
+
 		var popupUri = 'popup.html?errors=' + encodeURIComponent(errorsHtml) + '&host=' + encodeURIComponent(tabHost) + '&tabId=' + sender.tab.id;
 
 		chrome.pageAction.setPopup({

--- a/background.js
+++ b/background.js
@@ -22,6 +22,7 @@ function pluckHtml(x) {
 function initDefaultOptions() {
 	var optionsValues = {
 		showIcon: true,
+		showNotification: false,
 		ignore404others: true,
 		ignoreBlockedByClient: true,
 		relativeErrorUrl: true,
@@ -213,15 +214,17 @@ function handleErrorsRequest(data, sender, sendResponse) {
 			}
 		}
 
-		popupErrors.forEach(function(err) {
-			chrome.notifications.create(undefined, {
-				type: "basic",
-				title: tabBaseUrl,
-				message: err.text,
-				contextMessage: err.subtext,
-				iconUrl: "img/error_38.png",
+		if (localStorage['showNotification']) {
+			popupErrors.forEach(function(err) {
+				chrome.notifications.create(undefined, {
+					type: "basic",
+					title: tabBaseUrl,
+					message: err.text,
+					contextMessage: err.subtext,
+					iconUrl: "img/error_38.png",
+				});
 			});
-		});
+		}
 
 		var popupUri = 'popup.html?errors=' + encodeURIComponent(errorsHtml) + '&host=' + encodeURIComponent(tabHost) + '&tabId=' + sender.tab.id;
 

--- a/background.js
+++ b/background.js
@@ -11,6 +11,14 @@ function getBaseHostByUrl(url) {
 	return localUrlRegexp.exec(url) ? 'localhost' : (rootHostRegexp.exec(url) || subDomainRegexp.exec(url))[1];
 }
 
+function truthy(x) {
+	return x;
+}
+
+function pluckHtml(x) {
+	return x.html;
+}
+
 function initDefaultOptions() {
 	var optionsValues = {
 		showIcon: true,
@@ -112,9 +120,15 @@ function handleErrorsRequest(data, sender, sendResponse) {
 			}
 			error.type = 'File not found';
 			error.text = error.url;
-			popupErrors.unshift('File not found: ' + htmlentities(error.url));
+			popupErrors.unshift({
+				html: 'File not found: ' + htmlentities(error.url),
+				text: 'File not found: ' + error.url,
+			});
 		}
 		else {
+			var errorText = error.text;
+			var errorSubtext = [ error.url, error.line, error.col ].filter(truthy).join(':');
+
 			error.text = error.text.replace(/^Uncaught /, '').replace(/^Error: /, '');
 
 			var errorHtml = localStorage['linkStackOverflow']
@@ -159,7 +173,12 @@ function handleErrorsRequest(data, sender, sendResponse) {
 					? '<a href="view-source:' + error.url + (error.line ? '#' + error.line : '') + '" target="_blank">' + url + '</a>'
 					: url);
 			}
-			popupErrors.push(errorHtml);
+
+			popupErrors.push({
+				html: errorHtml,
+				text: errorText,
+				subtext: errorSubtext,
+			});
 		}
 	}
 
@@ -185,7 +204,7 @@ function handleErrorsRequest(data, sender, sendResponse) {
 			}
 		});
 
-		var errorsHtml = popupErrors.join('<br/><br/>');
+		var errorsHtml = popupErrors.map(pluckHtml).join('<br/><br/>');
 
 		if(localStorage['relativeErrorUrl'] && tabBaseUrl) {
 			errorsHtml = errorsHtml.split(tabBaseUrl + '/').join('/').split(tabBaseUrl).join('/');

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,7 @@
 		"<all_urls>",
 		"tabs",
 		"storage",
-		"webRequest"
+		"webRequest",
+		"notifications"
 	]
 }

--- a/options.html
+++ b/options.html
@@ -31,6 +31,11 @@
 	</label>
 
 	<label>
+		<input type="checkbox" id="showNotification" />
+		Show desktop notification for each error
+	</label>
+
+	<label>
 		<input type="checkbox" id="showPopupOnMouseOver" />
 		Show popup on notification icon mouseover
 	</label>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
 	var optionsIds = [
 		'showIcon',
 		'showPopup',
+		'showNotification',
 		'showPopupOnMouseOver',
 		'showColumn',
 		'showTrace',


### PR DESCRIPTION
This adds a basic `chrome.notifications` support:

 * a `showNotification` option is added, defaulting to false
 * `popupErrors` changed from array of html strings to array of `{html, text, subtext}` objects

 * when `showNotification` is true, a desktop notification is shown for any non-ignored errors:

![foo](https://user-images.githubusercontent.com/289743/35197709-3676950e-fedb-11e7-9a77-2dd06f1e58ea.png)

---

This is probably still missing code to destroy the notifications. Also, it looks like it behaves differently (ie not at all) for `console.error`, a missing hook somewhere?

If there's any interest in this, we could also look into click actions, and respecting more of the options which affect only the HTML popup now.