### PR TITLE
fix(unhandledRejection handler): use err.detail if err.reason is unavailable

### DIFF
--- a/content.js
+++ b/content.js
@@ -119,6 +119,9 @@ new function() {
 
 		// handle uncaught promises errors
 		window.addEventListener('unhandledrejection', function(e) {
+			if (typeof e.reason === 'undefined') {
+				e.reason = e.detail;
+			}
 			handleCustomError(e.reason.message, e.reason.stack);
 		});
 


### PR DESCRIPTION
this fixes cases in which bluebird emits the unhandledRejection event and assigns the original error to err.detail instead of err.reason	