### PR TITLE
Support XMLHttpRequest errors

### DIFF
--- a/background.js
+++ b/background.js
@@ -112,7 +112,7 @@ function handleErrorsRequest(data, sender, sendResponse) {
 			}
 			error.type = 'File not found';
 			error.text = error.url;
-			popupErrors.unshift('File not found: ' + htmlentities(error.url));
+			popupErrors.unshift('Failed to load: ' + htmlentities(error.url));
 		}
 		else {
 			error.text = error.text.replace(/^Uncaught /, '').replace(/^Error: /, '');

--- a/content.js
+++ b/content.js
@@ -165,6 +165,25 @@ new function() {
 				}));
 			}
 		}, true);
+
+		// handle 404 errors from xhr
+		XMLHttpRequest.prototype.jse__open = XMLHttpRequest.prototype.open
+		XMLHttpRequest.prototype.jse__onload = function(e) {
+			if (this.status >= 400) {
+				document.dispatchEvent(new CustomEvent('ErrorToExtension', {
+					detail: {
+						is404: true,
+						url: this.jse__url
+					}
+				}));
+			}
+		};
+		XMLHttpRequest.prototype.open = function(m, u, a) {
+			this.jse__url = u
+			this.addEventListener('load', this.jse__onload, { once : true });
+			return this.jse__open(m, u, a);
+		};
+
 	}
 
 	var script = document.createElement('script');


### PR DESCRIPTION
Small PR to track `XMLHttpRequest` errors, which would otherwise be ignored by the extension.